### PR TITLE
Adds the HNS address to .well-known/wallets

### DIFF
--- a/html/.well-known/wallets/HNS
+++ b/html/.well-known/wallets/HNS
@@ -1,0 +1,1 @@
+hs1qde7jaw6qgzzfu83upn3twvsyhh0zrshg76qe0x


### PR DESCRIPTION
This is the address from `hsd rpc getnameresource proofofconcept`.
After this PR is merged (and deployed) we should be able to access https://proofofconcept/.well-known/wallets/HNS and retrieve this address using a secure connection.